### PR TITLE
Make gradle substitutes version digits in plugin.yml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,3 +56,7 @@ task downloadMMOLib(type: Download) {
 }
 
 compileJava.dependsOn(downloadMMOLib)
+
+processResources {
+    expand(project.properties)
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CustomDisplay
-version: 1.10.9
+version: ${version}
 main: com.daxton.customdisplay.CustomDisplay
 api-version: 1.13
 prefix: CustomDisplay


### PR DESCRIPTION
configure `processResources` task to expand variables inside resources by `project.properties`.
By using `${version}`, the string will be substituted to the actual version digit while building.