### PR TITLE
Configure workflow to store built jars

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,3 +24,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Save the artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: CustomDisplay
+        path: build/libs/CustomDisplay-*.jar


### PR DESCRIPTION
Make Github Action stores built jars as artifacts.

![圖片](https://user-images.githubusercontent.com/45312147/101233089-20308100-36f1-11eb-9543-2e8318e80a83.png)
